### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/lib/libmedia_codec/CMakeLists.txt
+++ b/lib/libmedia_codec/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.5)
 project (robomaster_media_codec)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_BUILD_TYPE Release)


### PR DESCRIPTION
Recent versions of cmake do not support CMakeLists.txt files with cmake_minimum_required < 3.5