### PR TITLE
Better fix for CMake build errors

### DIFF
--- a/lib/libmedia_codec/CMakeLists.txt
+++ b/lib/libmedia_codec/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.4.1)
 project (robomaster_media_codec)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_BUILD_TYPE Release)

--- a/lib/libmedia_codec/pybind11/include/pybind11/attr.h
+++ b/lib/libmedia_codec/pybind11/include/pybind11/attr.h
@@ -12,6 +12,8 @@
 
 #include "cast.h"
 
+#include <cstdint>
+
 NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
 /// \addtogroup annotations

--- a/lib/libmedia_codec/pyproject.toml
+++ b/lib/libmedia_codec/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "cmake>=3.1.0", "pybind11"]
+requires = ["setuptools", "wheel", "cmake>=3.1.0,<4", "pybind11"]


### PR DESCRIPTION
Constrain cmake to <4.0.0 instead of changing the cmake_minimum_version, since the latter affects the default settings in unpredictable ways.